### PR TITLE
Make katalet.rb more Ruby-like

### DIFF
--- a/src/ruby/katalet.rb
+++ b/src/ruby/katalet.rb
@@ -1,8 +1,7 @@
 if ARGV.length == 0
-    puts "Please enter a katalet name."
-    exit
+  puts "Please enter a katalet name."
+  exit 1
 end
 
-kataName = ARGV[0]
-output = "The katalet you have selected is %s" % kataName
-puts output
+kata_name = ARGV[0]
+puts "The katalet you have selected is #{kata_name}"


### PR DESCRIPTION
Some formatting and convention updates:
- 2-space indents
- no camelCase var names
- string interpolation over formatting
- exit non-zero if ya done goofed
